### PR TITLE
fix: Handle empty task updates with confirmation dialog

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -78,6 +78,10 @@ app.put("/todos/:id", authMiddleware, async (req, res) => {
   try {
     const taskId = req.params.id;
     const updatedTextFromRequest = req.body.text;
+    //Checking if the New Text Is empty
+    if (updatedTextFromRequest.trim() === "") {
+      return;
+    }
     const objectId = new mongoose.Types.ObjectId(taskId);
     const updatedTodo = await Todo.findByIdAndUpdate(
       objectId,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-website",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/TodoList.jsx
+++ b/src/TodoList.jsx
@@ -165,6 +165,19 @@ function TodoList({ setIsLoggedIn }) {
   //Function to Edit TASKS
   const editTask = async (id, newText) => {
     setLoading(true);
+    if (newText === "") {
+      const confirmDelete = confirm(
+        "The task can't be empty. Would you like to delete the task instead?"
+      );
+      if (confirmDelete) {
+        deleteTask(id);
+        setLoading(false);
+        alert("Task Deleted!");
+      } else {
+        setLoading(false);
+        return;
+      }
+    }
     try {
       const response = await api.put(`/todos/${id}`, { text: newText });
 


### PR DESCRIPTION
fix: Handle Empty Task Updates with Confirmation Dialog

This pull request addresses an issue where users could submit empty updates for tasks.  The frontend now checks for empty input and prompts the user with a confirmation dialog, offering the option to either delete the task or cancel the update.  The backend has also been updated to handle empty updates gracefully.