### PR TITLE
Added password-toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.rest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "my-website",
-  "version": "0.0.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-website",
-      "version": "0.0.0",
+      "version": "0.7.1",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@popperjs/core": "^2.11.8",
         "axios": "^1.7.9",
         "bootstrap": "^5.3.3",
@@ -873,6 +876,52 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-website",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.5",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@popperjs/core": "^2.11.8",
     "axios": "^1.7.9",
     "bootstrap": "^5.3.3",

--- a/src/Components/usePasswordToggle.jsx
+++ b/src/Components/usePasswordToggle.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+
+const usePasswordToggle = () => {
+  const [Visible, setVisible] = useState(false);
+  const [passwordVisible, setPasswordVisible] = useState(false);
+  const Icon = <FontAwesomeIcon icon={Visible ? faEyeSlash : faEye} />;
+  const inputType = Visible ? "text" : "password";
+  const togglePasswordVisibility = () => {
+    setVisible((Visible) => !Visible);
+  };
+  return [inputType, Icon, togglePasswordVisibility];
+};
+
+export default usePasswordToggle;

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import PropTypes from "prop-types";
 import { LoadingContext } from "./LoadingContext.jsx";
 import LoadingSpinner from "./LoadingSpinner.jsx";
+import usePasswordToggle from "./Components/usePasswordToggle.jsx";
 
 function Login({ setIsLoggedIn }) {
   const [userLogin, setUserLogin] = useState("");
@@ -11,6 +12,8 @@ function Login({ setIsLoggedIn }) {
   //const [rememberme, setRememeberme] = useState(false);
   const [loginError, setLoginError] = useState(false);
   const { isLoading, setLoading } = useContext(LoadingContext);
+  const [passwordInputType, toggleIcon, togglePasswordVisibility] =
+    usePasswordToggle();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -66,10 +69,10 @@ function Login({ setIsLoggedIn }) {
               className="form-control"
             />
           </div>
-          <div className="mb-2">
+          <div className="password-field mb-2">
             <label htmlFor="password">Password</label>
             <input
-              type="password"
+              type={passwordInputType}
               value={password}
               onChange={(e) => setPassword(e.target.value.trim())}
               required
@@ -77,6 +80,12 @@ function Login({ setIsLoggedIn }) {
               placeholder="Enter Your Password"
               className="form-control"
             />
+            <span
+              className="password-toogle-icon"
+              onClick={togglePasswordVisibility}
+            >
+              {toggleIcon}
+            </span>
           </div>
           {/* <div className="mb-2">
           <input

--- a/src/Signup.jsx
+++ b/src/Signup.jsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 import { LoadingContext } from "./LoadingContext.jsx";
 import LoadingSpinner from "./LoadingSpinner.jsx";
+import usePasswordToggle from "./Components/usePasswordToggle.jsx";
 
 function Signup({ onSignup }) {
   const [username, setUsername] = useState("");
@@ -12,6 +13,8 @@ function Signup({ onSignup }) {
   const [showAlert, setShowAlert] = useState(false);
   const [signupError, setSignupError] = useState(null);
   const { isLoading, setLoading } = useContext(LoadingContext);
+  const [passwordInputType, toggleIcon, togglePasswordVisibility] =
+    usePasswordToggle();
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
@@ -92,7 +95,7 @@ function Signup({ onSignup }) {
           <div className="mb-2">
             <label htmlFor="password">Password</label>
             <input
-              type="password"
+              type={passwordInputType}
               id="password"
               value={password}
               onChange={(e) => setPassword(e.target.value.trim())}
@@ -100,6 +103,12 @@ function Signup({ onSignup }) {
               placeholder="Enter Your Password"
               className="form-control"
             />
+            <span
+              className="password-toogle-icon-signup"
+              onClick={togglePasswordVisibility}
+            >
+              {toggleIcon}
+            </span>
           </div>
           <div className="d-grid">
             <button className="btn btn-primary">Sign Up</button>

--- a/src/index.css
+++ b/src/index.css
@@ -259,3 +259,38 @@ span{
   display: flex;
   align-items: center;
 }
+.password-field{
+  position: relative;
+}
+.form_container .password-toogle-icon{
+  position: absolute;
+  top: 50%;
+  right: 15px;
+  transform: translate(-100%);
+  z-index: 1000;
+  cursor: pointer;
+}
+.form_container .password-toogle-icon-signup{
+  position: absolute;
+  top: 61%;
+  right: 62px;
+  transform: translate(-100%);
+  z-index: 1000;
+  cursor: pointer;
+}/**
+.form_container .password-toogle-icon-oldpassword{
+  position: absolute;
+  top: 27.2%;
+  right: 62px;
+  transform: translate(-100%);
+  z-index: 1000;
+  cursor: pointer;
+}
+.form_container .password-toogle-icon-password{
+  position: absolute;
+  top: 44.2%;
+  right: 62px;
+  transform: translate(-100%);
+  z-index: 1000;
+  cursor: pointer;
+}*/


### PR DESCRIPTION
feat: Add password visibility toggle

This commit adds a password visibility toggle to the login and sign-up forms, allowing users to easily view their entered password.

- Implemented a custom React hook (`usePasswordToggle`) to manage the toggle state and logic.
- Added an eye icon to the password input fields.
- Toggled the input type between "password" and "text" when the icon is clicked.
- Updated the icon to reflect the visibility state (open eye for visible, slashed eye for hidden).